### PR TITLE
Change configs json

### DIFF
--- a/config/dropbox.json
+++ b/config/dropbox.json
@@ -5,8 +5,11 @@
 
     "listener": {
       "ip": "0.0.0.0",
-      "port": 443,
-      "HTTPtoHTTPS": true
+      "port": 8443,
+      "HTTPtoHTTPS": {
+        "enabled": true,
+        "HTTPport": 8080
+      }
     },
 
     "skipContentType": [

--- a/config/github.com.json
+++ b/config/github.com.json
@@ -5,8 +5,11 @@
 
     "listener": {
       "ip": "0.0.0.0",
-      "port": 443,
-      "HTTPtoHTTPS": true
+      "port": 8443,
+      "HTTPtoHTTPS": {
+        "enabled": true,
+        "HTTPport": 8080
+      }
     },
 
     "skipContentType": [

--- a/config/google.com.json
+++ b/config/google.com.json
@@ -5,8 +5,11 @@
 
     "listener": {
       "ip": "0.0.0.0",
-      "port": 443,
-      "HTTPtoHTTPS": true
+      "port": 8443,
+      "HTTPtoHTTPS": {
+        "enabled": true,
+        "HTTPport": 8080
+      }
     },
 
     "skipContentType": [


### PR DESCRIPTION
There was an error with old configs:
```Error unmarshalling JSON configuration file config/config.json: json: cannot unmarshal bool into Go struct field .proxy.listener.HTTPtoHTTPS of type struct { Enabled bool "json:\"enabled\""; HTTPport int "json:\"HTTPport\"" }```

Because of bad json in config files.